### PR TITLE
fixing bug with exclusion of data/ folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,5 +96,3 @@ ENV/
 
 # vscode
 settings.json
-# any additional data being used for development
-data/


### PR DESCRIPTION
The exclusion of `data/` in the `.gitignore` file excludes all folders called "data", even subfolders.