### PR TITLE
[WIP] Upgrade Pandas to 3.0

### DIFF
--- a/.github/workflows/pip-installation.yml
+++ b/.github/workflows/pip-installation.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 keywords = ['FlowCytobot','Imaging','ifcb']
 dependencies = [
-    "numpy>=1.26,<3",
+    "numpy>=1.26,<2.3",
     "scipy>=1.13.1,<2",
     "pandas>=3.0.0,<4",
     "h5py>=3.12.1,<4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "pyifcb"
 version = "1.3.0"
 description = "Imaging FlowCytobot Python API, generation 2"
 readme = "README.md"
+requires-python = ">=3.11"
 authors = [{name = "Joe Futrelle", email = "jfutrelle@whoi.edu"},
             {name = "Shravani Nagala", email = "shravani.nagala@whoi.edu"}]
 classifiers = [
@@ -20,16 +21,17 @@ classifiers = [
 ]
 keywords = ['FlowCytobot','Imaging','ifcb']
 dependencies = [
-    "scipy==1.13.1",
-    "pandas==2.2.3",
-    "h5py==3.12.1",
-    "requests==2.32.4",
-    "Pillow==12.1.1",
-    "rectpack==0.2.2",
-    "scikit-image==0.24.0",
-    "pysmb==1.2.10",
-    "smbprotocol==1.15.0",
-    "pyyaml==6.0.2"
+    "numpy>=1.26,<3",
+    "scipy>=1.13.1,<2",
+    "pandas>=3.0.0,<4",
+    "h5py>=3.12.1,<4",
+    "requests>=2.32.4,<3",
+    "Pillow>=12.1.1,<13",
+    "rectpack>=0.2.2,<1",
+    "scikit-image>=0.24.0,<1",
+    "pysmb>=1.2.10,<2",
+    "smbprotocol>=1.15.0,<2",
+    "pyyaml>=6.0.2,<7"
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
This pull request updates the project's Python version support and modernizes dependency management to ensure compatibility with newer Python releases. The most important changes are grouped below:

**Python Version Support:**

* Updated the supported Python versions in both GitHub Actions workflows (`.github/workflows/pip-installation.yml` and `.github/workflows/python-package.yml`) to test against Python 3.11, 3.12, and 3.13, dropping support for 3.10. [[1]](diffhunk://#diff-27d8dadb7007706da85457ed0316248559300790d3846904d533f4909a0d83f5L14-R14) [[2]](diffhunk://#diff-ee49282f461b4c8ad179f79dd5bcdf93124561074c64a771366caf93e99b9320L19-R19)
* Set the minimum required Python version for the package to 3.11 in `pyproject.toml`.

**Dependency Management:**

* Changed the dependencies in `pyproject.toml` from strict pinned versions to version ranges, allowing for greater flexibility and compatibility with future releases. Most dependencies now specify a minimum version and an upper bound.